### PR TITLE
RNMT-3257 Cipher Local Storage plugin not working on Android 10

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -251,8 +251,13 @@ public class SecureStorage extends CordovaPlugin {
     private void unlockCredentials() {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
-                Intent intent = new Intent("com.android.credentials.UNLOCK");
-                startActivity(intent);
+                // Made in context of RNMT-3255
+                if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+                    startActivity(cordova.getActivity().getIntent());
+                } else {
+                    Intent intent = new Intent("com.android.credentials.UNLOCK");
+                    startActivity(intent);
+                }
             }
         });
     }

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -252,12 +252,14 @@ public class SecureStorage extends CordovaPlugin {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 // Made in context of RNMT-3255
+                Intent intent = null;
                 if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-                    startActivity(cordova.getActivity().getIntent());
+                    KeyguardManager keyguardManager = (KeyguardManager) (getContext().getSystemService(Context.KEYGUARD_SERVICE));
+                    intent = keyguardManager.createConfirmDeviceCredentialIntent(null, null);
                 } else {
-                    Intent intent = new Intent("com.android.credentials.UNLOCK");
-                    startActivity(intent);
+                    intent = new Intent("com.android.credentials.UNLOCK");
                 }
+                startActivity(intent);
             }
         });
     }


### PR DESCRIPTION
Intent "com.android.credentials.UNLOCK" is no longer supported by Android 10 (Q). The plugin is calling it because a lock mechanism is required in the Android OS to be able to encrypt the information in the storage.

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3257