### PR TITLE
fix: use 28 directly instead of referencing Build.VERSION_CODES.P

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -253,7 +253,7 @@ public class SecureStorage extends CordovaPlugin {
             public void run() {
                 // Made in context of RNMT-3255
                 Intent intent = null;
-                if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+                if(Build.VERSION.SDK_INT > 28) {
                     KeyguardManager keyguardManager = (KeyguardManager) (getContext().getSystemService(Context.KEYGUARD_SERVICE));
                     intent = keyguardManager.createConfirmDeviceCredentialIntent(null, null);
                 } else {


### PR DESCRIPTION
It is only defined in SDK 28 or higher so it fails to build in MABS 3 and 4.

References https://outsystemsrd.atlassian.net/browse/RNMT-3257