### PR TITLE
RNMT-3824 Errors in the first reads/writes of a Key Store when multiple initializations run simultaneously

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,9 +54,12 @@
             </feature>
         </config-file>
 
-        <source-file src="src/android/SecureStorage.java" target-dir="src/com/crypho/plugins/" />
-        <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/IntentRequest.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/IntentRequestQueue.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/IntentRequestType.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/SecureStorage.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/SharedPreferencesHandler.java" target-dir="src/com/crypho/plugins/" />
     </platform>
 

--- a/src/android/IntentRequest.java
+++ b/src/android/IntentRequest.java
@@ -1,0 +1,36 @@
+package com.crypho.plugins;
+
+import android.content.Intent;
+
+import org.apache.cordova.CallbackContext;
+
+class IntentRequest {
+
+    private IntentRequestType type;
+    private String service;
+    private Intent intent;
+    private CallbackContext context;
+
+    IntentRequest(IntentRequestType type, String service, Intent intent, CallbackContext context) {
+        this.type = type;
+        this.service = service;
+        this.intent = intent;
+        this.context = context;
+    }
+
+    IntentRequestType getType() {
+        return type;
+    }
+
+    String getService() {
+        return service;
+    }
+
+    Intent getIntent() {
+        return intent;
+    }
+
+    CallbackContext getCallbackContext() {
+        return context;
+    }
+}

--- a/src/android/IntentRequestQueue.java
+++ b/src/android/IntentRequestQueue.java
@@ -1,0 +1,67 @@
+package com.crypho.plugins;
+
+import android.content.Intent;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Enforces that only one intent is handled at a time
+class IntentRequestQueue {
+
+    private final Object LOCK = new Object();
+
+    private final CordovaPlugin plugin;
+    private final List<IntentRequest> requests;
+
+    IntentRequestQueue(CordovaPlugin plugin) {
+        this.plugin = plugin;
+        this.requests = new ArrayList<IntentRequest>();
+    }
+
+    void queueRequest(IntentRequestType type, String service, Intent intent, CallbackContext context) {
+        IntentRequest request = new IntentRequest(type, service, intent, context);
+        this.queueRequest(request);
+    }
+
+    void queueRequest(IntentRequest request) {
+        synchronized (LOCK) {
+
+            // Adds the request
+            this.requests.add(request);
+
+            // If the new request is the only request then handle it
+            if (this.requests.size() == 1) {
+                handleHeadRequest();
+            }
+        }
+    }
+
+    // Should be called in onActivityResult
+    IntentRequest notifyActivityResultCalled() {
+        synchronized (LOCK) {
+
+            // Remove the request (it already finished being handled)
+            IntentRequest request = this.requests.remove(0);
+
+            // If there are more requests then handle the first one
+            if (this.requests.size() > 0) {
+                handleHeadRequest();
+            }
+
+            return request;
+        }
+    }
+
+    // Handles the first request
+    private void handleHeadRequest() {
+        IntentRequest request = this.requests.get(0);
+        Intent intent = request.getIntent();
+
+        CordovaInterface cordova = this.plugin.cordova;
+        cordova.startActivityForResult(this.plugin, intent, 0);
+    }
+}

--- a/src/android/IntentRequestType.java
+++ b/src/android/IntentRequestType.java
@@ -1,0 +1,6 @@
+package com.crypho.plugins;
+
+enum IntentRequestType {
+    INIT,
+    SECURE_DEVICE
+}

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -1,7 +1,6 @@
 package com.crypho.plugins;
 
 import android.content.Context;
-import android.util.Log;
 
 import android.security.KeyPairGeneratorSpec;
 
@@ -18,64 +17,73 @@ public class RSA {
 	private static final String KEYSTORE_PROVIDER = "AndroidKeyStore";
 	private static final Cipher CIPHER = getCipher();
 
+	private static final Object LOCK = new Object();
+
 	public static byte[] encrypt(byte[] buf, String alias) throws Exception {
-		synchronized (CIPHER) {
+		synchronized (LOCK) {
 			initCipher(Cipher.ENCRYPT_MODE, alias);
 			return CIPHER.doFinal(buf);
 		}
 	}
 
 	public static byte[] decrypt(byte[] encrypted, String alias) throws Exception {
-		synchronized (CIPHER) {
+		synchronized (LOCK) {
 			initCipher(Cipher.DECRYPT_MODE, alias);
 			return CIPHER.doFinal(encrypted);
 		}
 	}
 
 	public static void createKeyPair(Context ctx, String alias) throws Exception {
-		Calendar notBefore = Calendar.getInstance();
-		Calendar notAfter = Calendar.getInstance();
-		notAfter.add(Calendar.YEAR, 100);
-		String principalString = String.format("CN=%s, OU=%s", alias, ctx.getPackageName());
-		KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(ctx)
-			.setAlias(alias)
-			.setSubject(new X500Principal(principalString))
-			.setSerialNumber(BigInteger.ONE)
-			.setStartDate(notBefore.getTime())
-			.setEndDate(notAfter.getTime())
-			.setEncryptionRequired()
-			.setKeySize(2048)
-			.setKeyType("RSA")
-			.build();
-		KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance("RSA", KEYSTORE_PROVIDER);
-		kpGenerator.initialize(spec);
-		kpGenerator.generateKeyPair();
+		synchronized (LOCK) {
+			Calendar notBefore = Calendar.getInstance();
+			Calendar notAfter = Calendar.getInstance();
+			notAfter.add(Calendar.YEAR, 100);
+			String principalString = String.format("CN=%s, OU=%s", alias, ctx.getPackageName());
+			KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(ctx)
+					.setAlias(alias)
+					.setSubject(new X500Principal(principalString))
+					.setSerialNumber(BigInteger.ONE)
+					.setStartDate(notBefore.getTime())
+					.setEndDate(notAfter.getTime())
+					.setEncryptionRequired()
+					.setKeySize(2048)
+					.setKeyType("RSA")
+					.build();
+			KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance("RSA", KEYSTORE_PROVIDER);
+			kpGenerator.initialize(spec);
+			kpGenerator.generateKeyPair();
+		}
 	}
 
 	public static void initCipher(int cipherMode, String alias) throws Exception {
-		KeyStore.PrivateKeyEntry keyEntry = getKeyStoreEntry(alias);
-		if (keyEntry == null) {
-			throw new Exception("Failed to load key for " + alias);
+		synchronized (LOCK) {
+			KeyStore.PrivateKeyEntry keyEntry = getKeyStoreEntry(alias);
+			if (keyEntry == null) {
+				throw new Exception("Failed to load key for " + alias);
+			}
+			Key key;
+			switch (cipherMode) {
+				case Cipher.ENCRYPT_MODE:
+					key = keyEntry.getCertificate().getPublicKey();
+					break;
+				case Cipher.DECRYPT_MODE:
+					key = keyEntry.getPrivateKey();
+					break;
+				default:
+					throw new Exception("Invalid cipher mode parameter");
+			}
+			CIPHER.init(cipherMode, key);
 		}
-		Key key;
-		switch (cipherMode) {
-            case Cipher.ENCRYPT_MODE:
-                key = keyEntry.getCertificate().getPublicKey();
-                break;
-			case  Cipher.DECRYPT_MODE:
-				key = keyEntry.getPrivateKey();
-				break;
-			default : throw new Exception("Invalid cipher mode parameter");
-		}
-		CIPHER.init(cipherMode, key);
 	}
 
 
 	public static boolean isEntryAvailable(String alias) {
-		try {
-			return getKeyStoreEntry(alias) != null;
-		} catch (Exception e) {
-			return false;
+		synchronized (LOCK) {
+			try {
+				return getKeyStoreEntry(alias) != null;
+			} catch (Exception e) {
+				return false;
+			}
 		}
 	}
 

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -3,7 +3,6 @@ package com.crypho.plugins;
 import java.lang.reflect.Method;
 import java.util.Hashtable;
 
-import android.app.Activity;
 import android.app.admin.DevicePolicyManager;
 import android.util.Log;
 import android.util.Base64;
@@ -22,8 +21,6 @@ import org.json.JSONArray;
 public class SecureStorage extends CordovaPlugin {
     private static final String TAG = "SecureStorage";
 
-    private static final int CREATE_CONFIRM_DEVICE_CREDENTIAL_REQUEST_CODE = 0x2F6A9F8C;
-
     private static final boolean SUPPORTS_NATIVE_AES = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     private static final boolean SUPPORTED = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
@@ -33,7 +30,6 @@ public class SecureStorage extends CordovaPlugin {
     private Hashtable<String, SharedPreferencesHandler> SERVICE_STORAGE = new Hashtable<String, SharedPreferencesHandler>();
     private String INIT_SERVICE;
     private volatile CallbackContext initContext, secureDeviceContext;
-    private volatile boolean initContextAllowed = false;
     private volatile boolean initContextRunning = false;
 
     @Override
@@ -52,24 +48,18 @@ public class SecureStorage extends CordovaPlugin {
                 public void run() {
                     initContextRunning = true;
                     try {
-                        if (initContextAllowed) {
-                            String alias = service2alias(INIT_SERVICE);
-                            if (!RSA.isEntryAvailable(alias)) {
-                                //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
-                                getStorage(INIT_SERVICE).clear();
-                                RSA.createKeyPair(getContext(), alias);
-                            }
-                            initSuccess(initContext);
-                        } else {
-                            Log.e(TAG, "Init failed : Authentication failed");
-                            initContext.error("Authentication failed");
+                        String alias = service2alias(INIT_SERVICE);
+                        if (!RSA.isEntryAvailable(alias)) {
+                            //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
+                            getStorage(INIT_SERVICE).clear();
+                            RSA.createKeyPair(getContext(), alias);
                         }
+                        initSuccess(initContext);
                     } catch (Exception e) {
                         Log.e(TAG, "Init failed :", e);
                         initContext.error(e.getMessage());
                     } finally {
                         initContext = null;
-                        initContextAllowed = false;
                         initContextRunning = false;
                     }
                 }
@@ -108,7 +98,6 @@ public class SecureStorage extends CordovaPlugin {
                 callbackContext.error(MSG_DEVICE_NOT_SECURE);
             } else if (!RSA.isEntryAvailable(alias)) {
                 initContext = callbackContext;
-                initContextAllowed = false;
                 unlockCredentials();
             } else {
                 initSuccess(callbackContext);
@@ -272,33 +261,21 @@ public class SecureStorage extends CordovaPlugin {
         });
     }
 
-    private void unlockCredentialsUsingUnlockIntent() {
-        initContextAllowed = true;
-        Intent intent = new Intent("com.android.credentials.UNLOCK");
-        startActivity(intent);
-    }
-
     // Made in context of RNMT-3255 and RNMT-3540
     private void unlockCredentialsUsingKeyguardManager() {
         KeyguardManager keyguardManager = (KeyguardManager) (getContext().getSystemService(Context.KEYGUARD_SERVICE));
         Intent intent = keyguardManager.createConfirmDeviceCredentialIntent(null, null);
 
-        if (intent != null) {
-            startActivityForResult(intent, CREATE_CONFIRM_DEVICE_CREDENTIAL_REQUEST_CODE);
-
-        } else {
+        if (intent == null) {
             intent = new Intent(DevicePolicyManager.ACTION_SET_NEW_PASSWORD);
-            startActivity(intent);
         }
+
+        startActivity(intent);
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
-        if (requestCode == CREATE_CONFIRM_DEVICE_CREDENTIAL_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            initContextAllowed = true;
-        }
-
-        super.onActivityResult(requestCode, resultCode, intent);
+    private void unlockCredentialsUsingUnlockIntent() {
+        Intent intent = new Intent("com.android.credentials.UNLOCK");
+        startActivity(intent);
     }
 
     private Context getContext() {
@@ -309,7 +286,4 @@ public class SecureStorage extends CordovaPlugin {
         cordova.getActivity().startActivity(intent);
     }
 
-    private void startActivityForResult(Intent intent, int requestCode) {
-        cordova.startActivityForResult(this, intent, requestCode);
-    }
 }


### PR DESCRIPTION
## Description
Removes the previous fix.
Improves mutual exclusion in concurrent init calls.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3824

<!--- Why is this change required? What problem does it solve? -->
Simultaneous init calls were not being handled correctly. We added proper mutual exclusion and a queue that guarantees only one intent is handled at a time to prevent intent cancellation.

Please review the 2 commits separately for maximum comfort.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests were performed using Android 9 (uses old intent) and 10 (uses new intent).

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly