### PR TITLE
RMET-377 Bad store count with store names with same name as plugin tag

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -267,20 +267,29 @@ public class SecureStorage extends CordovaPlugin {
         editor.commit();
     }
 
-    private int initializePreferences() {
+   private int initializePreferences() {
 
         Context ctx = getContext();
         File prefdir = new File(ctx.getApplicationInfo().dataDir,"shared_prefs");
         String[] filenames = prefdir.list();
         int i = 0;
         for(String name : filenames){
-            if(name.contains("SS")){
-                String alias = name.substring(0, name.length() - 4);
-                String service = alias.substring(ctx.getPackageName().length() + 1, alias.length() -3);
+            String packageName = ctx.getPackageName();
+            if(name.contains(packageName) && name.length() > packageName.length()){
+                //obtaining only the store name and plugin tag minus file extension
+                String pluginTag = name.substring(packageName.length(),name.length() - 4);
+                //to avoid any errors with the store name we only take from the end of the  string
+                int begin = pluginTag.lastIndexOf("_SS");
+                int end = pluginTag.lastIndexOf(" ", begin);
+                if(pluginTag.contains("_SS") && begin != -1 && end == -1){
+                    String alias = name.substring(0, name.length() - 4);
+                    String service = alias.substring(ctx.getPackageName().length() + 1, alias.length() -3);
 
-                SharedPreferencesHandler PREFS = new SharedPreferencesHandler(alias, getContext());
-                putStorage(service, PREFS);
-                i+=1;
+                    SharedPreferencesHandler PREFS = new SharedPreferencesHandler(alias, getContext());
+                    putStorage(service, PREFS);
+                    i+=1;
+                }
+
             }
         }
         return i;

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -275,20 +275,14 @@ public class SecureStorage extends CordovaPlugin {
         int i = 0;
         for(String name : filenames){
             String packageName = ctx.getPackageName();
-            if(name.contains(packageName) && name.length() > packageName.length()){
-                //obtaining only the store name and plugin tag minus file extension
-                String pluginTag = name.substring(packageName.length(),name.length() - 4);
-                //to avoid any errors with the store name we only take from the end of the  string
-                int begin = pluginTag.lastIndexOf("_SS");
-                int end = pluginTag.lastIndexOf(" ", begin);
-                if(pluginTag.contains("_SS") && begin != -1 && end == -1){
-                    String alias = name.substring(0, name.length() - 4);
-                    String service = alias.substring(ctx.getPackageName().length() + 1, alias.length() -3);
+            if(name.startsWith(ctx.getPackageName()) && name.endsWith("_SS.xml")){
+                String alias = name.substring(0, name.length() - 4);
+                String service = alias.substring(ctx.getPackageName().length() + 1, alias.length() -3);
 
-                    SharedPreferencesHandler PREFS = new SharedPreferencesHandler(alias, getContext());
-                    putStorage(service, PREFS);
-                    i+=1;
-                }
+                SharedPreferencesHandler PREFS = new SharedPreferencesHandler(alias, getContext());
+                putStorage(service, PREFS);
+                i+=1;
+
 
             }
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes in how stores produced by the plugin are counted taking into account some more strict checking to make sure wrongful counts don't pass
## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly