### PR TITLE
RMET-1292 fix: modified to test above android 6 on handle lock

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -501,7 +501,8 @@ public class SecureStorage extends CordovaPlugin {
             public void run() {
                 Log.v(TAG, "Handling lock screen");
 
-                if (Build.VERSION.SDK_INT >= 29) { // >= Android 10
+                // fix applied in context of RMET-1182
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
                     handleLockScreenUsingNoOpOrSetNewPasswordIntent(type, service, callbackContext);
                 } else {
                     handleLockScreenUsingUnlockIntent(type, service, callbackContext);
@@ -511,12 +512,11 @@ public class SecureStorage extends CordovaPlugin {
     }
 
     // Made in context of RNMT-3255, RNMT-3540 and RNMT-3803
-    @TargetApi(29)
     private void handleLockScreenUsingNoOpOrSetNewPasswordIntent(IntentRequestType type, String service, CallbackContext callbackContext) {
-        Log.v(TAG, "Handling lock screen via KeyguardManager or ACTION_SET_NEW_PASSWORD intent (Android 10 or newer)");
+        Log.v(TAG, "Handling lock screen via KeyguardManager or ACTION_SET_NEW_PASSWORD intent (Android 6 or newer)");
 
         if (isDeviceSecure()) {
-            Log.v(TAG, "Unlocking Android devices above 10 using KeyguardManager");
+            Log.v(TAG, "Unlocking Android devices above 6 using KeyguardManager");
             KeyguardManager keyguardManager = (KeyguardManager) (getContext().getSystemService(Context.KEYGUARD_SERVICE));
             Intent intent = keyguardManager.createConfirmDeviceCredentialIntent(null, null);
             // Lock screen is already defined, unlock it via KeyguardManager
@@ -532,7 +532,7 @@ public class SecureStorage extends CordovaPlugin {
     }
 
     private void handleLockScreenUsingUnlockIntent(IntentRequestType type, String service, CallbackContext callbackContext) {
-        Log.v(TAG, "Handling lock screen via UNLOCK intent (Android 9 or earlier)");
+        Log.v(TAG, "Handling lock screen via UNLOCK intent (Android 6 or earlier)");
 
         // Requests a new lock screen or requests to unlock if required
         Intent intent = new Intent("com.android.credentials.UNLOCK");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the method handleLockScreen on SecureStorage.java, modified the if to test above android 6 and not above android 9.
The method createConfirmDeviceCredentialIntent is deprecated in the API 29 but works in post versions and is supported by the minimum version that is 24.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly