### PR TITLE
RMET-1374 ::: Fix - verify if the key is valid before to use it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,9 @@ Changelog
 2.6.8-OS9 - 2022-01-28
 ------------------
 
+- Fix: Implementation the validation of the keys before to use. (RMET-1374)
 - Fix: Implementation of the skip flow in the authentication. (RMET-1373)
+
 2.6.8-OS8 - 2022-01-05
 ------------------
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In Android 7 devices, after change the PIN, when access the keys, an error was being returned: Key permanently invalidated.
When we change the PIN the key will be invalidade for security reasons, but if the self healing preference is set to true, is not supposed to give error in the OutSystems side.

This fix was added by @usernuno to verify if the keys are valid before to continue the flow.

With this verification we avoid the error in the OutSystems side, and redirect the plugin to the correct flow that is recreate the database using the self healing mechanism.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
references: https://outsystemsrd.atlassian.net/browse/RMET-1374

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual Testes executed and validated with the customer in the support case: https://outsystemsrd.atlassian.net/browse/RMET-1182

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
