### PR TITLE
RMET-1182 ::: Fix - Ciphered Database Errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.6.8-OS11 - 2022-04-12
+------------------
+
+- Fix: Fix for the error messages: Keystore operation failed, User not authenticated, Key not yet valid. (RMET-1182)
+
+
 2.6.8-OS9 - 2022-01-28
 ------------------
 

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -46,12 +46,7 @@ public class RSA {
 
 	public static void createKeyPair(Context ctx, String alias) throws Exception {
 		synchronized (LOCK) {
-			Calendar notBefore = Calendar.getInstance();
 
-			//this back dates the date of the key in order to avoid some timezone issues found during use with some devices
-			notBefore.add(Calendar.HOUR_OF_DAY, -26);
-			Calendar notAfter = Calendar.getInstance();
-			notAfter.add(Calendar.YEAR, 100);
 			String principalString = String.format("CN=%s, OU=%s", alias, ctx.getPackageName());
 
 			if(Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
@@ -66,8 +61,6 @@ public class RSA {
 						.setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
 						.setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
 						.setRandomizedEncryptionRequired(true)
-						.setKeyValidityStart(notBefore.getTime())
-						.setKeyValidityEnd(notAfter.getTime())
 					    .setInvalidatedByBiometricEnrollment(false);
 				KeyGenParameterSpec spec = builder.build();
 				generator.initialize(spec);
@@ -80,8 +73,6 @@ public class RSA {
 						.setAlias(alias)
 						.setSubject(new X500Principal(principalString))
 						.setSerialNumber(BigInteger.ONE)
-						.setStartDate(notBefore.getTime())
-						.setEndDate(notAfter.getTime())
 						.setEncryptionRequired()
 						.setKeySize(2048)
 						.setKeyType("RSA")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix for the error messages:
Keystore operation failed
User not authenticated 
Key not yet valid

Work done in colaboration with @OS-ricardomoreirasilva 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
references: https://outsystemsrd.atlassian.net/browse/RMET-1182

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual Testes executed and validated with the customer in the support case: https://outsystemsrd.atlassian.net/browse/RMET-1182

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
