### PR TITLE
RPM-2504 ::: Avoid Keychain's errSecInteractionNotAllowed error on iOS 15

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.6.8-OS12 - 2022-04-14
+------------------
+
+- Fix: For iOS 15, on the `init` method, if ProtectedData is unavailable, add an observer for the `UIApplicationProtectedDataDidBecomeAvailable` notification that re-triggers `init` when it becomes available. (RMET-1417)
+
 2.6.8-OS11 - 2022-04-12
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.8-OS11",
+  "version": "2.6.8-OS12",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.8-OS11">
+    version="2.6.8-OS12">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>


### PR DESCRIPTION
## Description
For iOS 15, on `SecureStorage`'s `init` method, if `ProtectedData` is unavailable, add an observer for the `UIApplicationProtectedDataDidBecomeAvailable` notification that re-triggers init when it becomes available.

## Context
https://outsystemsrd.atlassian.net/browse/RPM-2504

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
iOS

## Tests
The issue couldn't be replicated.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
