### PR TITLE
RMET-2045 - KeyStore Plugin - Use fixed versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ------------------
 
+- Fix: [Android] Replace dynamic gradle versions by fixed versions. (https://outsystemsrd.atlassian.net/browse/RMET-2045)
+
 2.6.8-OS14 - 2022-11-09
 ------------------
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.+'
+        classpath 'com.android.tools.build:gradle:3.6.4'
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- We should fix versions for gradle dependencies instead of leaving it to the compiler to decide which version to use.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2045

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 and 9 builds. Tested plugin in Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
