### PR TITLE
RMET-2062 ::: iOS ::: Return Empty Result

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ------------------
 
+- Fix: [iOS] When there are no keys associated with a store, return empty string instead of `nil`.
+
 2.6.8-OS14 - 2022-11-09
 ------------------
 

--- a/src/ios/SecureStorage.swift
+++ b/src/ios/SecureStorage.swift
@@ -132,7 +132,7 @@ extension SecureStorage: PlatformProtocol {
             ]
             pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorDict);
         } else if let result = result {
-            pluginResult = result.isEmpty ? CDVPluginResult(status: CDVCommandStatus_OK) : CDVPluginResult(status: CDVCommandStatus_OK, messageAs: result)
+            pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: result)
         }
 
         self.commandDelegate.send(pluginResult, callbackId: callBackID);


### PR DESCRIPTION
## Description
On iOS, When there are no keys associated with a store, return empty string instead of `nil`. This is an issue related with the `keys` method so it concerns only the `Ciphered Local Storage` plugin.

To test the issue, a Sample App build for `Ciphered Local Storage` was created. It can be checked [here](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=8f75bf7b075ed5d7e14e04f9ff796c9dcef5a196).

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2062

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
