### PR TITLE
RMET-2036 - Removed dependency to jcenter()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ------------------
 
+### 16-12-2022
+- Removed dependency to  jcenter() [RMET-2036](https://outsystemsrd.atlassian.net/browse/RMET-2036)
+
 - Fix: [Android] Replace dynamic gradle versions by fixed versions. (https://outsystemsrd.atlassian.net/browse/RMET-2045)
 
 2.6.8-OS15 - 2022-11-23

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,11 +17,6 @@ repositories {
     }
 }
 
-repositories{
-    jcenter()
-}
-
-
 apply plugin: 'kotlin-kapt'
 
 dependencies {


### PR DESCRIPTION
## Description
- Removed the dependency to `jcenter()` from gradle

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2036

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on MABS 8 and MABS 9 builds, on Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
