### PR TITLE
RMET-2190 KeyStore Plugin - Include alternative method of authentication for Android <= 10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ------------------
 
+### 20-01-2023
+Android - Add alternative authentication for Android below 11 (https://outsystemsrd.atlassian.net/browse/RMET-2190)
+
 2.6.8-OS16 - 2022-12-19
 
 ### 16-12-2022

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -693,8 +693,11 @@ public class SecureStorage extends CordovaPlugin {
                     this.callbackContext.success();
                     break;
 
+                case KeystoreController.RESULT_DEVICE_NOT_SECURE:
+                    sendError(KeystoreError.DEVICE_NOT_SECURE);
+                    break;
+
                 case Activity.RESULT_CANCELED:
-                    //send error saying user cancelled
                     sendError(KeystoreError.AUTHENTICATION_FAILED_ERROR);
 
                 default:
@@ -714,8 +717,11 @@ public class SecureStorage extends CordovaPlugin {
                     }
                     break;
 
+                case KeystoreController.RESULT_DEVICE_NOT_SECURE:
+                    sendError(KeystoreError.DEVICE_NOT_SECURE);
+                    break;
+
                 case Activity.RESULT_CANCELED:
-                    //send error saying user cancelled
                     sendError(KeystoreError.AUTHENTICATION_FAILED_ERROR);
 
                 default:
@@ -735,8 +741,11 @@ public class SecureStorage extends CordovaPlugin {
                     }
                     break;
 
+                case KeystoreController.RESULT_DEVICE_NOT_SECURE:
+                    sendError(KeystoreError.DEVICE_NOT_SECURE);
+                    break;
+
                 case Activity.RESULT_CANCELED:
-                    //send error saying user cancelled
                     sendError(KeystoreError.AUTHENTICATION_FAILED_ERROR);
 
                 default:
@@ -754,6 +763,10 @@ public class SecureStorage extends CordovaPlugin {
                     else{
                         sendError(KeystoreError.AUTHENTICATION_FAILED_ERROR);
                     }
+                    break;
+
+                case KeystoreController.RESULT_DEVICE_NOT_SECURE:
+                    sendError(KeystoreError.DEVICE_NOT_SECURE);
                     break;
 
                 case Activity.RESULT_CANCELED:

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -395,8 +395,14 @@ public class SecureStorage extends CordovaPlugin {
             keystoreController.showBiometricPrompt(cordova.getActivity(), KeystoreController.REQUEST_CODE_BIOMETRIC_SET);
         }
         else{
-            keystoreController.setValueEncrypted(cordova.getActivity());
-            this.callbackContext.success();
+            try{
+                keystoreController.setValueEncrypted(cordova.getActivity());
+                this.callbackContext.success();
+            }
+            catch (Exception e){
+                Log.d(TAG, e.getMessage());
+                sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
+            }
         }
         return true;
     }
@@ -443,12 +449,18 @@ public class SecureStorage extends CordovaPlugin {
                 keystoreController.showBiometricPrompt(cordova.getActivity(), KeystoreController.REQUEST_CODE_BIOMETRIC_GET);
             }
             else{
-                String value = keystoreController.getValueEncrypted(cordova.getActivity());
-                if(value != null){
-                    callbackContext.success(value);
+                try{
+                    String value = keystoreController.getValueEncrypted(cordova.getActivity());
+                    if(value != null){
+                        callbackContext.success(value);
+                    }
+                    else{
+                        sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                    }
                 }
-                else{
-                    sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                catch (Exception e){
+                    Log.d(TAG, e.getMessage());
+                    sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
                 }
             }
         }
@@ -552,12 +564,18 @@ public class SecureStorage extends CordovaPlugin {
                 keystoreController.showBiometricPrompt(cordova.getActivity(), KeystoreController.REQUEST_CODE_BIOMETRIC_REMOVE);
             }
             else{
-                Boolean removed = keystoreController.removeKeyEncrypted(cordova.getActivity());
-                if(removed){
-                    callbackContext.success();
+                try{
+                    Boolean removed = keystoreController.removeKeyEncrypted(cordova.getActivity());
+                    if(removed){
+                        callbackContext.success();
+                    }
+                    else{
+                        sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                    }
                 }
-                else{
-                    sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                catch (Exception e){
+                    Log.d(TAG, e.getMessage());
+                    sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
                 }
             }
         }
@@ -689,8 +707,14 @@ public class SecureStorage extends CordovaPlugin {
             switch (resultCode){
 
                 case Activity.RESULT_OK:
-                    keystoreController.setValueEncrypted(cordova.getActivity());
-                    this.callbackContext.success();
+                    try{
+                        keystoreController.setValueEncrypted(cordova.getActivity());
+                        this.callbackContext.success();
+                    }
+                    catch (Exception e){
+                        Log.d(TAG, e.getMessage());
+                        sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
+                    }
                     break;
 
                 case KeystoreController.RESULT_DEVICE_NOT_SECURE:
@@ -708,12 +732,18 @@ public class SecureStorage extends CordovaPlugin {
             switch (resultCode){
 
                 case Activity.RESULT_OK:
-                    String value = keystoreController.getValueEncrypted(cordova.getActivity());
-                    if(value != null){
-                        this.callbackContext.success(value);
+                    try{
+                        String value = keystoreController.getValueEncrypted(cordova.getActivity());
+                        if(value != null){
+                            this.callbackContext.success(value);
+                        }
+                        else{
+                            sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                        }
                     }
-                    else{
-                        sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                    catch (Exception e){
+                        Log.d(TAG, e.getMessage());
+                        sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
                     }
                     break;
 
@@ -732,12 +762,18 @@ public class SecureStorage extends CordovaPlugin {
             switch (resultCode){
 
                 case Activity.RESULT_OK:
-                    Boolean removed = keystoreController.removeKeyEncrypted(cordova.getActivity());
-                    if(removed){
-                        this.callbackContext.success();
+                    try{
+                        Boolean removed = keystoreController.removeKeyEncrypted(cordova.getActivity());
+                        if(removed){
+                            this.callbackContext.success();
+                        }
+                        else{
+                            sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                        }
                     }
-                    else{
-                        sendError(KeystoreError.KEY_NOT_FOUND_ERROR);
+                    catch (Exception e){
+                        Log.d(TAG, e.getMessage());
+                        sendError(KeystoreError.KEYSTORE_GENERAL_ERROR);
                     }
                     break;
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.1@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.2@aar")
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.0@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.1@aar")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updated OSKeystoreLib-Android, so now we need to deal with an error that was added to it ("Device is not secure").
- Also added `try-catch` clauses to deal with errors accessing the EncryptedSharedPreferences.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2190


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 and 9 builds, on Android 12, 11, 10, 9 and 8.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
