### PR TITLE
RMET-2994 KeyStore Plugin - Remove allow backup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ------------------
 
+2.6.8-OS18 - 2024-01-11
+------------------
+
+- Fix: [Android] Update OSKeystoreLib version to fix incompatibility issue with AppFeedback (https://outsystemsrd.atlassian.net/browse/RMET-2994).
+
 - Feat: [iOS] Make library available as `xcframework` (https://outsystemsrd.atlassian.net/browse/RMET-2280).
 
 2.6.8-OS17 - 2023-01-20

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.2@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.3@aar")
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.3@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.4@aar")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to https://github.com/OutSystems/OSKeystoreLib-Android, bringing the fix in version `1.0.4`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-2994

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested on Android 14 (Pixel 7)

- MABS build of KeyStore sample app: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=7fe1b0c2b93dc4111385a26f7e5c72eaa3eb5adf
- MABS build of Ciphered Local Storage sample app: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=361e6c664b8807f82104be7806b6734919fb568a

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
