### PR TITLE
RMET-3408 KeyStore Plugin - Set auth prompt text (title, subtitle, and negative button)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ------------------
 
+2.6.8-OS19 - 2024-05-03
+------------------
+
+- Feat: [Android] Add parameters for title, subtitle, and negative button text of Biometric Prompt (https://outsystemsrd.atlassian.net/browse/RMET-3408).
+
 2.6.8-OS18 - 2024-01-11
 ------------------
 

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -8,6 +8,7 @@ module.exports = function (context) {
     const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     const configXML = path.join(projectRoot, 'config.xml');
     const configParser = new ConfigParser(configXML);
+    const parser = new DOMParser();
 
     const authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
     const auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -52,14 +52,14 @@ module.exports = function (context) {
     // set text for each <string> element
     for (let i = 0; i < stringElements.length; i++) {
         const name = stringElements[i].getAttribute('name');
-        if (name == "biometric_prompt_title") {
-            stringElements[i].textContent = authenticate;
+        if (name == "biometric_prompt_title" && auth_prompt_title != "") {
+            stringElements[i].textContent = auth_prompt_title;
         }
-        else if (name == "biometric_prompt_subtitle") {
-            stringElements[i].textContent = notificationDescription;
+        else if (name == "biometric_prompt_subtitle" && auth_prompt_subtitle != "") {
+            stringElements[i].textContent = auth_prompt_subtitle;
         }
-        else if (name == "biometric_prompt_negative_button") {
-            stringElements[i].textContent = notificationDescription;
+        else if (name == "biometric_prompt_negative_button" && auth_prompt_negative_button) {
+            stringElements[i].textContent = auth_prompt_negative_button;
         }
     }
 

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -5,13 +5,14 @@ const { ConfigParser } = require('cordova-common');
 const { DOMParser, XMLSerializer } = require('xmldom');
 
 module.exports = function (context) {
-    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    let configXML = path.join(projectRoot, 'config.xml');
-    let configParser = new ConfigParser(configXML);
-    let authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
-    let auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')
-    let auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle')
-    let auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton')
+    const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    const configXML = path.join(projectRoot, 'config.xml');
+    const configParser = new ConfigParser(configXML);
+
+    const authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
+    const auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')
+    const auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle')
+    const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton')
 
     const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
@@ -32,9 +33,8 @@ module.exports = function (context) {
         fs.writeFileSync(stringsXmlPath, resultXmlStrings);
         */
 
-        // insert values in strings.xml
+        // insert bool value in strings.xml
         
-
         const booleanElements = stringsXmlDoc.getElementsByTagName('bool');
         
         // set text for each <bool> element
@@ -47,6 +47,7 @@ module.exports = function (context) {
 
     }
 
+    // insert string values in strings.xml
     const stringElements = stringsXmlDoc.getElementsByTagName('string');
 
     // set text for each <string> element

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -8,10 +8,10 @@ module.exports = function (context) {
     let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     let configXML = path.join(projectRoot, 'config.xml');
     let configParser = new ConfigParser(configXML);
-    let authenticate = configParser.getGlobalPreference("MigratedKeysAuthentication");
-    let auth_prompt_title = configParser.getPreference("AuthPromptTitle")
-    let auth_prompt_subtitle = configParser.getPreference("AuthPromptSubtitle")
-    let auth_prompt_negative_button = configParser.getPreference("AuthPromptCancelButton")
+    let authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
+    let auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')
+    let auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle')
+    let auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton')
 
     const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -1,4 +1,3 @@
-const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
 const { ConfigParser } = require('cordova-common');
@@ -20,24 +19,9 @@ module.exports = function (context) {
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
     if(authenticate == "true"){
-        /*
-        var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
-        var stringsXmlContents = fs.readFileSync(stringsXmlPath).toString();
-        var etreeStrings = et.parse(stringsXmlContents);
-
-        var migrationAuthTags = etreeStrings.findall('./bool[@name="migration_auth"]');
-        for (var i = 0; i < migrationAuthTags.length; i++) {
-            migrationAuthTags[i].text = authenticate;
-        }
-
-        var resultXmlStrings = etreeStrings.write();
-        fs.writeFileSync(stringsXmlPath, resultXmlStrings);
-        */
-
         // insert bool value in strings.xml
-        
         const booleanElements = stringsXmlDoc.getElementsByTagName('bool');
-        
+
         // set text for each <bool> element
         for (let i = 0; i < booleanElements.length; i++) {
             const name = booleanElements[i].getAttribute('name');
@@ -45,7 +29,6 @@ module.exports = function (context) {
                 booleanElements[i].textContent = authenticate;
             }
         }
-
     }
 
     // insert string values in strings.xml
@@ -71,6 +54,5 @@ module.exports = function (context) {
 
     // write the updated XML string back to the same file
     fs.writeFileSync(stringsXmlPath, updatedXmlString, 'utf-8');
-
 
 };

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -43,7 +43,7 @@ module.exports = function (context) {
         else if (name == "biometric_prompt_subtitle" && auth_prompt_subtitle != "") {
             stringElements[i].textContent = auth_prompt_subtitle;
         }
-        else if (name == "biometric_prompt_negative_button" && auth_prompt_negative_button) {
+        else if (name == "biometric_prompt_negative_button" && auth_prompt_negative_button != "") {
             stringElements[i].textContent = auth_prompt_negative_button;
         }
     }

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -12,8 +12,8 @@ module.exports = function (context) {
 
     const authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
     const auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')
-    const auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle')
-    const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton')
+    const auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle', 'android')
+    const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton', 'android')
 
     const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -2,14 +2,23 @@ const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
 const { ConfigParser } = require('cordova-common');
+const { DOMParser, XMLSerializer } = require('xmldom');
 
 module.exports = function (context) {
-    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    var configXML = path.join(projectRoot, 'config.xml');
-    var configParser = new ConfigParser(configXML);
-    var authenticate = configParser.getGlobalPreference("MigratedKeysAuthentication");    
+    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    let configXML = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configXML);
+    let authenticate = configParser.getGlobalPreference("MigratedKeysAuthentication");
+    let auth_prompt_title = configParser.getPreference("AuthPromptTitle")
+    let auth_prompt_subtitle = configParser.getPreference("AuthPromptSubtitle")
+    let auth_prompt_negative_button = configParser.getPreference("AuthPromptCancelButton")
+
+    const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
+    const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
+    const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
     if(authenticate == "true"){
+        /*
         var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
         var stringsXmlContents = fs.readFileSync(stringsXmlPath).toString();
         var etreeStrings = et.parse(stringsXmlContents);
@@ -21,5 +30,45 @@ module.exports = function (context) {
 
         var resultXmlStrings = etreeStrings.write();
         fs.writeFileSync(stringsXmlPath, resultXmlStrings);
+        */
+
+        // insert values in strings.xml
+        
+
+        const booleanElements = stringsXmlDoc.getElementsByTagName('bool');
+        
+        // set text for each <bool> element
+        for (let i = 0; i < booleanElements.length; i++) {
+            const name = booleanElements[i].getAttribute('name');
+            if (name == "migration_auth") {
+                booleanElements[i].textContent = authenticate;
+            }
+        }
+
     }
+
+    const stringElements = stringsXmlDoc.getElementsByTagName('string');
+
+    // set text for each <string> element
+    for (let i = 0; i < stringElements.length; i++) {
+        const name = stringElements[i].getAttribute('name');
+        if (name == "biometric_prompt_title") {
+            stringElements[i].textContent = authenticate;
+        }
+        else if (name == "biometric_prompt_subtitle") {
+            stringElements[i].textContent = notificationDescription;
+        }
+        else if (name == "biometric_prompt_negative_button") {
+            stringElements[i].textContent = notificationDescription;
+        }
+    }
+
+    // serialize the updated XML document back to string
+    const serializer = new XMLSerializer();
+    const updatedXmlString = serializer.serializeToString(stringsXmlDoc);
+
+    // write the updated XML string back to the same file
+    fs.writeFileSync(stringsXmlPath, updatedXmlString, 'utf-8');
+
+
 };

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   "bugs": {
     "url": "https://github.com/crypho/cordova-plugin-secure-storage/issues"
   },
-  "homepage": "https://github.com/crypho/cordova-plugin-secure-storage#readme"
+  "homepage": "https://github.com/crypho/cordova-plugin-secure-storage#readme",
+  "dependencies": {
+    "xmldom": "^0.6.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.8-OS18",
+  "version": "2.6.8-OS19",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,9 @@
 
         <config-file parent="/resources" target="res/values/strings.xml">
             <bool name="migration_auth">false</bool>
+            <string name="biometric_prompt_title">Authentication required</string>
+            <string name="biometric_prompt_subtitle">Please authenticate to continue</string>
+            <string name="biometric_prompt_negative_button">Cancel</string>
         </config-file>
 
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.8-OS18">
+    version="2.6.8-OS19">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -31,6 +31,7 @@ import android.util.Pair;
 
 import com.outsystems.plugins.keystore.controller.KeystoreController;
 import com.outsystems.plugins.keystore.controller.KeystoreError;
+import com.outsystems.plugins.keystore.controller.OSKSTRBiometricPromptInfo;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -75,8 +76,13 @@ public class SecureStorage extends CordovaPlugin {
 
         intentRequestQueue = new IntentRequestQueue(this);
 
-        keystoreController = new KeystoreController();
-
+        keystoreController = new KeystoreController(
+                new OSKSTRBiometricPromptInfo(
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_title"),
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_subtitle"),
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_negative_button")
+                )
+        );
     }
 
 
@@ -946,6 +952,14 @@ public class SecureStorage extends CordovaPlugin {
 
     private int getBooleanResourceId(Activity activity, String name) {
         return activity.getResources().getIdentifier(name, "bool", activity.getPackageName());
+    }
+
+    private int getStringResourceId(Activity activity, String name) {
+        return activity.getResources().getIdentifier(name, "string", activity.getPackageName());
+    }
+
+    private String getStringResource(Activity activity, String name) {
+        return activity.getString(getStringResourceId(activity, name));
     }
    
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.1.0@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.4.1@aar")
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.4@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.4.1@aar")
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.4.1@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.1.0@aar")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR introduces the usage of the `AuthPromptTitle - title`, `AuthPromptSubtitle - subtitle`, and `AuthPromptCancelButton - negativeButtonText` fields in the plugin, passing them in the `constructor` of `KeystoreController.kt`.
- It also updates hook `androidCopyPreferences.js` to account for these new values to copy to `strings.xml`.
- It also updates the dependency to version `1.1.0` of `OSKeystoreLib-Android`.


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-3408

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=6dd947261db6ca083a4c4704d9d23aaf24d9c66c

MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=d55b3294b16788ed1a12a01e97c72c264ad7eec1

Tested in the following devices:

- Android 14 Pixel 7
- Android 13 Samsung A51
- Android 12 Pixel 3XL
- Android 10 (Pixel 4 emulator)

## Screenshots (if appropriate)

Android 14 device showing the `title` and `subtitle` fields being used:

![IMG_5473](https://github.com/OutSystems/OSKeystoreLib-Android/assets/27646996/4c4392aa-84bb-44ff-9f14-6eef9e443135)

Android 10 device showing the `negative button text` field being used:

![dsdsdsdsds](https://github.com/OutSystems/OSKeystoreLib-Android/assets/27646996/e0105526-fedb-4276-9be2-c6132e381dce)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
