### PR TITLE
RMET-3408 KeyStore Plugin - Prepare release of version `2.6.8-OS19`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ------------------
 
+2.6.8-OS19 - 2024-05-03
+------------------
+
+- Feat: [Android] Add parameters for title, subtitle, and negative button text of Biometric Prompt (https://outsystemsrd.atlassian.net/browse/RMET-3408).
+
 2.6.8-OS18 - 2024-01-11
 ------------------
 

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -1,25 +1,58 @@
-const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
 const { ConfigParser } = require('cordova-common');
+const { DOMParser, XMLSerializer } = require('xmldom');
 
 module.exports = function (context) {
-    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    var configXML = path.join(projectRoot, 'config.xml');
-    var configParser = new ConfigParser(configXML);
-    var authenticate = configParser.getGlobalPreference("MigratedKeysAuthentication");    
+    const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    const configXML = path.join(projectRoot, 'config.xml');
+    const configParser = new ConfigParser(configXML);
+    const parser = new DOMParser();
+
+    const authenticate = configParser.getGlobalPreference('MigratedKeysAuthentication');
+    const auth_prompt_title = configParser.getPreference('AuthPromptTitle', 'android')
+    const auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle', 'android')
+    const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton', 'android')
+
+    const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
+    const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
+    const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
     if(authenticate == "true"){
-        var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
-        var stringsXmlContents = fs.readFileSync(stringsXmlPath).toString();
-        var etreeStrings = et.parse(stringsXmlContents);
+        // insert bool value in strings.xml
+        const booleanElements = stringsXmlDoc.getElementsByTagName('bool');
 
-        var migrationAuthTags = etreeStrings.findall('./bool[@name="migration_auth"]');
-        for (var i = 0; i < migrationAuthTags.length; i++) {
-            migrationAuthTags[i].text = authenticate;
+        // set text for each <bool> element
+        for (let i = 0; i < booleanElements.length; i++) {
+            const name = booleanElements[i].getAttribute('name');
+            if (name == "migration_auth") {
+                booleanElements[i].textContent = authenticate;
+            }
         }
-
-        var resultXmlStrings = etreeStrings.write();
-        fs.writeFileSync(stringsXmlPath, resultXmlStrings);
     }
+
+    // insert string values in strings.xml
+    const stringElements = stringsXmlDoc.getElementsByTagName('string');
+
+    // set text for each <string> element
+    for (let i = 0; i < stringElements.length; i++) {
+        const name = stringElements[i].getAttribute('name');
+        if (name == "biometric_prompt_title" && auth_prompt_title != "") {
+            stringElements[i].textContent = auth_prompt_title;
+        }
+        else if (name == "biometric_prompt_subtitle" && auth_prompt_subtitle != "") {
+            stringElements[i].textContent = auth_prompt_subtitle;
+        }
+        else if (name == "biometric_prompt_negative_button" && auth_prompt_negative_button != "") {
+            stringElements[i].textContent = auth_prompt_negative_button;
+        }
+    }
+
+    // serialize the updated XML document back to string
+    const serializer = new XMLSerializer();
+    const updatedXmlString = serializer.serializeToString(stringsXmlDoc);
+
+    // write the updated XML string back to the same file
+    fs.writeFileSync(stringsXmlPath, updatedXmlString, 'utf-8');
+
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.8-OS18",
+  "version": "2.6.8-OS19",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [
@@ -50,5 +50,8 @@
   "bugs": {
     "url": "https://github.com/crypho/cordova-plugin-secure-storage/issues"
   },
-  "homepage": "https://github.com/crypho/cordova-plugin-secure-storage#readme"
+  "homepage": "https://github.com/crypho/cordova-plugin-secure-storage#readme",
+  "dependencies": {
+    "xmldom": "^0.6.0"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.8-OS18">
+    version="2.6.8-OS19">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>
@@ -66,6 +66,9 @@
 
         <config-file parent="/resources" target="res/values/strings.xml">
             <bool name="migration_auth">false</bool>
+            <string name="biometric_prompt_title">Authentication required</string>
+            <string name="biometric_prompt_subtitle">Please authenticate to continue</string>
+            <string name="biometric_prompt_negative_button">Cancel</string>
         </config-file>
 
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -31,6 +31,7 @@ import android.util.Pair;
 
 import com.outsystems.plugins.keystore.controller.KeystoreController;
 import com.outsystems.plugins.keystore.controller.KeystoreError;
+import com.outsystems.plugins.keystore.controller.OSKSTRBiometricPromptInfo;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -75,8 +76,13 @@ public class SecureStorage extends CordovaPlugin {
 
         intentRequestQueue = new IntentRequestQueue(this);
 
-        keystoreController = new KeystoreController();
-
+        keystoreController = new KeystoreController(
+                new OSKSTRBiometricPromptInfo(
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_title"),
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_subtitle"),
+                        getStringResource(this.cordova.getActivity(), "biometric_prompt_negative_button")
+                )
+        );
     }
 
 
@@ -946,6 +952,14 @@ public class SecureStorage extends CordovaPlugin {
 
     private int getBooleanResourceId(Activity activity, String name) {
         return activity.getResources().getIdentifier(name, "bool", activity.getPackageName());
+    }
+
+    private int getStringResourceId(Activity activity, String name) {
+        return activity.getResources().getIdentifier(name, "string", activity.getPackageName());
+    }
+
+    private String getStringResource(Activity activity, String name) {
+        return activity.getString(getStringResourceId(activity, name));
     }
    
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.4@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.0.4.1@aar")
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
     implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("com.github.outsystems:oskeystore-android:1.0.4.1@aar")
+    implementation("com.github.outsystems:oskeystore-android:1.1.0@aar")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Merges `development` into `outsystems`.
- This has already been review in https://github.com/OutSystems/cordova-plugin-secure-storage/pull/28

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3408

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
