### PR TITLE
RMET-4037 ::: iOS ::: Remove `cordova-plugin-add-swift-support` Plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+[Unreleased]
+------------------
+- Chore: [iOS] Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).
+
 2.6.8-OS20 - 2024-09-11
 ------------------
 - Feat: [Android] Update Error Codes (https://outsystemsrd.atlassian.net/browse/RMET-3607).

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,14 +28,11 @@
     </engines>
 
     <platform name="ios">
-         <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
-
         <config-file target="config.xml" parent="/*">
             <feature name="SecureStorage">
                 <param name="ios-package" value="SecureStorage"/>
-                <preference name="deployment-target" value="13" />
-                <preference name="UseSwiftLanguageVersion" value="5" />
             </feature>
+            <preference name="SwiftVersion" value="5" />
         </config-file>
         
         <source-file src="src/ios/SecureStorage.swift"/>


### PR DESCRIPTION
## Description
The only thing the plugin needs is the `SwiftVersion`. This is included directly on `plugin.xml`.

### Information Regarding the Failing Check
The `snyk` validation is failing due to a dependency used for an Android hook. As this falls outside the scope of this task, this PR will not be addressing it.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4037

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
