### PR TITLE
RMET-4025 - Update hook to avoid duplicates in strings.xml

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+------------------
+- Fix: [android] Updates hook to avoid duplicates in `strings.xml` (https://outsystemsrd.atlassian.net/browse/RMET-4025).
+
 2.6.8-OS21 - 2025-02-07
 ------------------
 - Chore: [iOS] Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -32,7 +32,7 @@ module.exports = function (context) {
     boolDuplicates.forEach(el => el.parentNode.removeChild(el));
 
     // Add new <bool> if needed
-    if (authenticate === "true") {
+    if (authenticate == "true") {
         const newBool = stringsXmlDoc.createElement('bool');
         newBool.setAttribute('name', boolKey);
         newBool.textContent = authenticate;

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -26,30 +26,52 @@ module.exports = function (context) {
         biometric_prompt_negative_button: auth_prompt_negative_button
     };
 
-    // === Remove duplicate <bool> entries ===
+    // process <bool> entry
     const boolElements = Array.from(stringsXmlDoc.getElementsByTagName('bool'));
-    const boolDuplicates = boolElements.filter(el => el.getAttribute('name') === boolKey);
-    boolDuplicates.forEach(el => el.parentNode.removeChild(el));
+    const boolMatches = boolElements.filter(el => el.getAttribute('name') === boolKey);
 
-    // Add new <bool> if needed
     if (authenticate == "true") {
-        const newBool = stringsXmlDoc.createElement('bool');
-        newBool.setAttribute('name', boolKey);
-        newBool.textContent = authenticate;
-        stringsXmlDoc.documentElement.appendChild(newBool);
+        if (boolMatches.length > 0) {
+            // remove any duplicates beyond the first
+            for (let i = 1; i < boolMatches.length; i++) {
+                boolMatches[i].parentNode.removeChild(boolMatches[i]);
+            }
+
+            // update first match if needed
+            const existingBool = boolMatches[0];
+            if (existingBool.textContent !== authenticate) {
+                existingBool.textContent = authenticate;
+            }
+        } else {
+            // add new <bool> if it doesn't exist
+            const newBool = stringsXmlDoc.createElement('bool');
+            newBool.setAttribute('name', boolKey);
+            newBool.textContent = authenticate;
+            stringsXmlDoc.documentElement.appendChild(newBool);
+        }
     }
 
-    // === Remove duplicate <string> entries ===
-    const existingStrings = Array.from(stringsXmlDoc.getElementsByTagName('string'));
+    // process <string> entries
+    const allStrings = Array.from(stringsXmlDoc.getElementsByTagName('string'));
 
-    for (const [key, value] of Object.entries(stringKeys)) {
-        // Remove existing <string> with this name
-        existingStrings
-            .filter(el => el.getAttribute('name') === key)
-            .forEach(el => el.parentNode.removeChild(el));
+    for (const [key, value] of Object.entries(stringUpdates)) {
+        if (!value || value.trim() === "") continue;
 
-        // Add new <string> if value is not empty
-        if (value && value.trim() !== "") {
+        const matchingStrings = allStrings.filter(el => el.getAttribute('name') === key);
+
+        if (matchingStrings.length > 0) {
+            // remove duplicates beyond the first
+            for (let i = 1; i < matchingStrings.length; i++) {
+                matchingStrings[i].parentNode.removeChild(matchingStrings[i]);
+            }
+
+            // update first if needed
+            const existingString = matchingStrings[0];
+            if (existingString.textContent !== value) {
+                existingString.textContent = value;
+            }
+        } else {
+            // add new <string> if it doesn't exist
             const newString = stringsXmlDoc.createElement('string');
             newString.setAttribute('name', key);
             newString.textContent = value;

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -54,7 +54,7 @@ module.exports = function (context) {
     // process <string> entries
     const allStrings = Array.from(stringsXmlDoc.getElementsByTagName('string'));
 
-    for (const [key, value] of Object.entries(stringUpdates)) {
+    for (const [key, value] of Object.entries(stringKeys)) {
         if (!value || value.trim() === "") continue;
 
         const matchingStrings = allStrings.filter(el => el.getAttribute('name') === key);

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -18,33 +18,42 @@ module.exports = function (context) {
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
-    if(authenticate == "true"){
-        // insert bool value in strings.xml
-        const booleanElements = stringsXmlDoc.getElementsByTagName('bool');
+    // Keys to update and their values
+    const boolKey = "migration_auth";
+    const stringKeys = {
+        biometric_prompt_title: auth_prompt_title,
+        biometric_prompt_subtitle: auth_prompt_subtitle,
+        biometric_prompt_negative_button: auth_prompt_negative_button
+    };
 
-        // set text for each <bool> element
-        for (let i = 0; i < booleanElements.length; i++) {
-            const name = booleanElements[i].getAttribute('name');
-            if (name == "migration_auth") {
-                booleanElements[i].textContent = authenticate;
-            }
-        }
+    // === Remove duplicate <bool> entries ===
+    const boolElements = Array.from(stringsXmlDoc.getElementsByTagName('bool'));
+    const boolDuplicates = boolElements.filter(el => el.getAttribute('name') === boolKey);
+    boolDuplicates.forEach(el => el.parentNode.removeChild(el));
+
+    // Add new <bool> if needed
+    if (authenticate === "true") {
+        const newBool = stringsXmlDoc.createElement('bool');
+        newBool.setAttribute('name', boolKey);
+        newBool.textContent = authenticate;
+        stringsXmlDoc.documentElement.appendChild(newBool);
     }
 
-    // insert string values in strings.xml
-    const stringElements = stringsXmlDoc.getElementsByTagName('string');
+    // === Remove duplicate <string> entries ===
+    const existingStrings = Array.from(stringsXmlDoc.getElementsByTagName('string'));
 
-    // set text for each <string> element
-    for (let i = 0; i < stringElements.length; i++) {
-        const name = stringElements[i].getAttribute('name');
-        if (name == "biometric_prompt_title" && auth_prompt_title != "") {
-            stringElements[i].textContent = auth_prompt_title;
-        }
-        else if (name == "biometric_prompt_subtitle" && auth_prompt_subtitle != "") {
-            stringElements[i].textContent = auth_prompt_subtitle;
-        }
-        else if (name == "biometric_prompt_negative_button" && auth_prompt_negative_button != "") {
-            stringElements[i].textContent = auth_prompt_negative_button;
+    for (const [key, value] of Object.entries(stringKeys)) {
+        // Remove existing <string> with this name
+        existingStrings
+            .filter(el => el.getAttribute('name') === key)
+            .forEach(el => el.parentNode.removeChild(el));
+
+        // Add new <string> if value is not empty
+        if (value && value.trim() !== "") {
+            const newString = stringsXmlDoc.createElement('string');
+            newString.setAttribute('name', key);
+            newString.textContent = value;
+            stringsXmlDoc.documentElement.appendChild(newString);
         }
     }
 
@@ -54,5 +63,4 @@ module.exports = function (context) {
 
     // write the updated XML string back to the same file
     fs.writeFileSync(stringsXmlPath, updatedXmlString, 'utf-8');
-
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

-  Updates hook to avoid duplicates in `strings.xml`
- If the hook runs more than once in a build for some reason, the values it adds to `strings.xml` would be duplicated, which would cause the Android build to fail.
- This happens when building apps with MOCA instead of MABS

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4025

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in MABS 11.1 builds with MOCA.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
