### PR TITLE
fix(android): remove unnecessary `kotlin-kapt`, fixing Capacitor builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ Changelog
 
 2.6.8-OS24 - 2025-09-30
 ------------------
-- Fix: [android] Update build action to add Kotlin Gradle Plugin to app's build.gradle file (https://outsystemsrd.atlassian.net/browse/RMET-4515)
+- Fix: [android] Removes the `kotlin-kapt` plugin that was being added, fixing builds for Capacitor apps (https://outsystemsrd.atlassian.net/browse/RMET-4515)
 
 2.6.8-OS23 - 2025-07-08
 ------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.6.8-OS24 - 2025-09-30
+------------------
+- Fix: [android] Update build action to add Kotlin Gradle Plugin to app's build.gradle file (https://outsystemsrd.atlassian.net/browse/RMET-4515)
+
 2.6.8-OS23 - 2025-07-08
 ------------------
 - Fix: [android] Updates hook to avoid duplicates in `strings.xml` (https://outsystemsrd.atlassian.net/browse/RMET-4025).

--- a/build-actions/setStringsAndroid.yaml
+++ b/build-actions/setStringsAndroid.yaml
@@ -23,3 +23,10 @@ platforms:
             <string name="biometric_prompt_negative_button">$BIOMETRIC_PROMPT_NEGATIVE_BTN</string>
             <bool name="migration_auth">$MIGRATE_KEYS_AUTH</bool>
           </resources>
+    gradle:
+    - file: build.gradle
+      target:
+        buildscript:
+          dependencies:
+      insert:
+        - classpath: "'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25'"

--- a/build-actions/setStringsAndroid.yaml
+++ b/build-actions/setStringsAndroid.yaml
@@ -23,10 +23,3 @@ platforms:
             <string name="biometric_prompt_negative_button">$BIOMETRIC_PROMPT_NEGATIVE_BTN</string>
             <bool name="migration_auth">$MIGRATE_KEYS_AUTH</bool>
           </resources>
-    gradle:
-    - file: build.gradle
-      target:
-        buildscript:
-          dependencies:
-      insert:
-        - classpath: "'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.8-OS23",
+  "version": "2.6.8-OS24",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.8-OS23">
+    version="2.6.8-OS24">
   
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,8 +17,6 @@ repositories {
     }
 }
 
-apply plugin: 'kotlin-kapt'
-
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.1.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- removes the `kotlin-kapt` plugin that was being added, fixing builds for Capacitor apps once the changes in [this PR](https://github.com/OutSystems/capacitor-mobile-nativeshell/pull/152) are merged

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4515

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested by generating MABS 12 build of the KeyStore Sample App in ODC and removing the entry that comes from the Android Capacitor template, to simulate what a MABS 12 build will be like once this is removed from the template.

Also tested this with MABS 11.2 and 11.1 builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
