### PR TITLE
fix(android): missing strings.xml on target project

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.6.8-OS25 - 2025-11-14
+------------------
+- Fix: [android] Fixes missing strings.xml on target project (https://outsystemsrd.atlassian.net/browse/RMET-4780)
+
 2.6.8-OS24 - 2025-09-30
 ------------------
 - Fix: [android] Removes the `kotlin-kapt` plugin that was being added, fixing builds for Capacitor apps (https://outsystemsrd.atlassian.net/browse/RMET-4515)

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -14,7 +14,20 @@ module.exports = function (context) {
     const auth_prompt_subtitle = configParser.getPreference('AuthPromptSubtitle', 'android')
     const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton', 'android')
 
-    const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
+        // create XML with correct values directly
+    var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/os_sociallogins_strings.xml');
+
+    const xmlContent = `<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <bool name="migration_auth">false</bool>
+    <string name="biometric_prompt_title">Authentication required</string>
+    <string name="biometric_prompt_subtitle">Please authenticate to continue</string>
+    <string name="biometric_prompt_negative_button">Cancel</string>
+</resources>`;
+
+    // write XML file directly
+    fs.writeFileSync(stringsXmlPath, xmlContent);
+
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -15,7 +15,7 @@ module.exports = function (context) {
     const auth_prompt_negative_button = configParser.getPreference('AuthPromptCancelButton', 'android')
 
         // create XML with correct values directly
-    var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/os_sociallogins_strings.xml');
+    var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/os_keystore_strings.xml');
 
     const xmlContent = `<?xml version='1.0' encoding='utf-8'?>
 <resources>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage",
-  "version": "2.6.8-OS24",
+  "version": "2.6.8-OS25",
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage"
-    version="2.6.8-OS24">
+    version="2.6.8-OS25">
   
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -61,13 +61,6 @@
             <preference name="AndroidXEnabled" value="true"/>
         </config-file>
 
-        <config-file parent="/resources" target="res/values/strings.xml">
-            <bool name="migration_auth">false</bool>
-            <string name="biometric_prompt_title">Authentication required</string>
-            <string name="biometric_prompt_subtitle">Please authenticate to continue</string>
-            <string name="biometric_prompt_negative_button">Cancel</string>
-        </config-file>
-
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/IntentRequest.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/IntentRequestQueue.java" target-dir="src/com/crypho/plugins/" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updated the `androidCopyPreferences` hook to set the strings in a custom `os_keystore_strings.xml` file it creates instead of assuming `strings.xml` exists.
- Fixes MABS 12 Cordova builds.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4780

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested with MABS 12 build on O11.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
