### PR TITLE
chore: remove unnecessary dependency to OSCommonLib on iOS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.6.8-OS26 - 2026-01-05
+------------------
+- Chore: [iOS] Remove unnecessary dependency to OSCommonPluginLib on iOS (https://outsystemsrd.atlassian.net/browse/RMET-4899)
+
 2.6.8-OS25 - 2025-11-14
 ------------------
 - Fix: [android] Fixes missing strings.xml on target project (https://outsystemsrd.atlassian.net/browse/RMET-4780)

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,15 +37,6 @@
         
         <source-file src="src/ios/SecureStorage.swift"/>
         <framework src="src/ios/frameworks/OSKeyStoreLib.xcframework" embed="true" custom="true" />
-
-        <podspec>
-            <config>
-                <source url="https://cdn.cocoapods.org/"/>
-            </config>
-            <pods use-frameworks="true">
-                <pod name="OSCommonPluginLib" spec="1.0.0" />
-            </pods>
-        </podspec>
     </platform>
 
     <platform name="android">

--- a/src/ios/SecureStorage.swift
+++ b/src/ios/SecureStorage.swift
@@ -1,4 +1,3 @@
-import OSCommonPluginLib
 import OSKeyStoreLib
 
 @objc(SecureStorage)
@@ -119,11 +118,8 @@ class SecureStorage: CDVPlugin {
             self.plugin?.delete(service: service)
         }
     }
-}
-
-// MARK: - OSCore's PlatformProtocol Methods
-extension SecureStorage: PlatformProtocol {
-    func sendResult(result: String?, error: NSError?, callBackID: String) {
+    
+    private func sendResult(result: String?, error: NSError?, callBackID: String) {
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR)
 
         if let error = error {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Check the Jira ticket in **Context** for the rationale behind removing this dependency.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4899

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [x] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

You can use the following MABS build to test:

- [MABS build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=5d59c4e12dd37979968ff20b5446b161b53776f7&stg=dev)

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly