### PR TITLE
feat: Support for SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /node_modules/
-
 .idea
 .gradle
 local.properties
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,11 @@ import PackageDescription
 
 let package = Package(
     name: "cordova-plugin-secure-storage",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "cordova-plugin-secure-storage",
-            targets: ["cordova-plugin-secure-storage"])
+            targets: ["SecureStoragePlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
@@ -18,15 +18,16 @@ let package = Package(
             path: "src/ios/frameworks/OSKeyStoreLib.xcframework"
         ),
         .target(
-            name: "cordova-plugin-secure-storage",
+            name: "SecureStoragePlugin",
             dependencies: [
                 .product(name: "Cordova", package: "cordova-ios"),
                 .target(name: "OSKeyStoreLib")
             ],
             path: "src/ios",
-            sources: ["SecureStorage.swift"],
             exclude: [
                 "frameworks/OSKeyStoreLib.xcframework"
-            ])
+            ],
+            sources: ["SecureStorage.swift"]
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,14 @@ import PackageDescription
 
 let package = Package(
     name: "cordova-plugin-secure-storage",
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "cordova-plugin-secure-storage",
-            targets: ["cordova-plugin-secure-storage"]
-        )
+            targets: ["cordova-plugin-secure-storage"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
     ],
     targets: [
         .binaryTarget(
@@ -16,9 +19,13 @@ let package = Package(
         ),
         .target(
             name: "cordova-plugin-secure-storage",
-            dependencies: ["OSKeyStoreLib"],
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .target(name: "OSKeyStoreLib")
+            ],
             path: "src/ios",
-            sources: ["SecureStorage.swift"]
-        )
+            exclude: [
+                "frameworks/OSKeyStoreLib.xcframework"
+            ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "cordova-plugin-secure-storage",
+    products: [
+        .library(
+            name: "cordova-plugin-secure-storage",
+            targets: ["cordova-plugin-secure-storage"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "OSKeyStoreLib",
+            path: "src/ios/frameworks/OSKeyStoreLib.xcframework"
+        ),
+        .target(
+            name: "cordova-plugin-secure-storage",
+            dependencies: ["OSKeyStoreLib"],
+            path: "src/ios",
+            sources: ["SecureStorage.swift"]
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                 .target(name: "OSKeyStoreLib")
             ],
             path: "src/ios",
+            sources: ["SecureStorage.swift"],
             exclude: [
                 "frameworks/OSKeyStoreLib.xcframework"
             ])

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <config-file target="config.xml" parent="/*">
             <feature name="SecureStorage">
                 <param name="ios-package" value="SecureStorage"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,8 +35,8 @@
             <preference name="SwiftVersion" value="5" />
         </config-file>
         
-        <source-file src="src/ios/SecureStorage.swift"/>
-        <framework src="src/ios/frameworks/OSKeyStoreLib.xcframework" embed="true" custom="true" />
+        <source-file src="src/ios/SecureStorage.swift" nospm="true"/>
+        <framework src="src/ios/frameworks/OSKeyStoreLib.xcframework" embed="true" custom="true" nospm="true"/>
     </platform>
 
     <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,8 +35,8 @@
             <preference name="SwiftVersion" value="5" />
         </config-file>
         
-        <source-file src="src/ios/SecureStorage.swift" nospm="true"/>
-        <framework src="src/ios/frameworks/OSKeyStoreLib.xcframework" embed="true" custom="true" nospm="true"/>
+        <source-file src="src/ios/SecureStorage.swift"/>
+        <framework src="src/ios/frameworks/OSKeyStoreLib.xcframework" embed="true" custom="true" />
     </platform>
 
     <platform name="android">

--- a/src/ios/SecureStorage.swift
+++ b/src/ios/SecureStorage.swift
@@ -1,3 +1,6 @@
+#if canImport(Cordova)
+import Cordova
+#endif
 import OSKeyStoreLib
 
 @objc(SecureStorage)


### PR DESCRIPTION
**This PR adds support for SPM by:**

- Adding a `Package.swift` file with the required dependencies for SPM support.
- Updating `plugin.xml` to add `package="swift"` on the iOS platform and `nospm="true"` on all iOS source files, so the SPM build path uses `Package.swift` exclusively

**Tests**

**Ciphered plugin**
✅ Cordova iOS CocoaPods — no regression [ciphered-cdv ipa](https://github.com/user-attachments/files/27016869/ciphered-cdv.ipa.zip)
✅ Capacitor iOS CocoaPods — no regression [ciphered-cap ipa](https://github.com/user-attachments/files/27016906/ciphered-cap.ipa.zip)
❌ Capacitor iOS SPM — not yet tested, blocked by missing implementation in Capacitor CLI — [RMET-5117](https://outsystemsrd.atlassian.net/browse/RMET-5117)

However, you can use this sample app to test [zip attached](https://github.com/user-attachments/files/27018600/capacitor-ciphered-exampleapp.zip)

**Note:** do not run `npm install`, as the `package.json` points to local paths. The `node_modules` in the zip are already set up and ready to test, just open the app in Xcode and build.

**KeyStore**
✅ Cordova iOS CocoaPods — no regression [keystore-cdv ipa](https://github.com/user-attachments/files/27018755/keystore-cdv.ipa.zip)
✅ Capacitor iOS CocoaPods — no regression [keystore-cap ipa](https://github.com/user-attachments/files/27018763/keystore-cap.ipa.zip)

**References**

Ciphered - https://outsystemsrd.atlassian.net/browse/RMET-5136
KeyStore - https://outsystemsrd.atlassian.net/browse/RMET-5118




[RMET-5117]: https://outsystemsrd.atlassian.net/browse/RMET-5117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ