### PR TITLE
chore(android): Remove kotlin declaration from plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,8 +36,6 @@
             <feature name="SecureStorage">
                 <param name="android-package" value="com.crypho.plugins.SecureStorage"/>
             </feature>
-            <preference name="GradlePluginKotlinEnabled" value="true"/>
-            <preference name="GradlePluginKotlinCodeStyle" value="official"/>
             <preference name="AndroidXEnabled" value="true"/>
         </config-file>
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/"/>


### PR DESCRIPTION
This PR removes kotlin preferences from `plugin.xml`, as the Plugin has no Kotlin Source Code.

For OutSystems apps this doesn't really change anything because those always have kotlin enabled by default. And even if they didn't, it doesn't change anything because the plugin as no Kotlin code. So we don't need to release a new version of an OutSystems Plugin because of this.

The Kotlin Preference was added in https://github.com/OutSystems/cordova-plugin-secure-storage/pull/18, and while https://github.com/OutSystems/OSKeyStoreLib-android is built with Kotlin, perhaps there was plans to move this plugin to kotlin as well but it's fully Java, and again, because OutSystems apps always have kotlin declared (tbf they didn't at the time of that PR), we're safe.

This PR is really more just for consistency sake.

Successful MABS build with this branch (sanity check): https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=8ff0af60fe0d87ee3098dc5e21e7da977b549a8b&stg=dev

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-5359